### PR TITLE
Compile out all calls to process.env.NODE_ENV

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ router.get('/rax', raxRoute.default);
 // not understand.
 router.get('/vue', function *() {
 
-  const VueApp = require('./assets/build/server.vue.bundle').default;
+  const VueApp = require('./assets/build/app.vue.bundle').default;
   const pageConfig = {
     listData: require('./mock/list'),
     bannerData: require('./mock/banner')

--- a/app.js
+++ b/app.js
@@ -1,16 +1,12 @@
 'use strict';
 
-process.env.NODE_ENV = 'production';
-
 const fs = require('fs');
 const koa = require('koa');
 const serve = require('koa-static');
 const router = require('koa-router')();
 
-const React = require('react');
-const ReactDOMServer = require('react-dom/server');
-const Rax = require('rax');
-const raxRenderToString = require('rax-server-renderer').renderToString;
+const reactRoute = require('./assets/build/route.react.bundle');
+const raxRoute = require('./assets/build/route.rax.bundle');
 const Vue = require('vue');
 const vueRenderToString = require('vue-server-renderer').createRenderer().renderToString;
 
@@ -18,40 +14,13 @@ const app = require('xtpl/lib/koa')(require('koa')(), {
   views:'./views'
 });
 
-router.get('/react', function *() {
+router.get('/react', reactRoute.default);
 
-  const ReactApp = require('./assets/build/server.react.bundle').default;
+router.get('/rax', raxRoute.default);
 
-  const pageConfig = {
-    listData: require('./mock/list'),
-    bannerData: require('./mock/banner')
-  };
-
-  yield this.render('page', {
-    type: 'react',
-    content: ReactDOMServer.renderToString(
-                React.createElement(ReactApp, pageConfig)
-              ),
-    global: JSON.stringify(pageConfig)
-  });
-});
-
-router.get('/rax', function *() {
-
-  const RaxApp = require('./assets/build/server.rax.bundle').default;
-  const pageConfig = {
-    listData: require('./mock/list'),
-    bannerData: require('./mock/banner')
-  };
-
-  yield this.render('page', {
-    type: 'rax',
-    content: raxRenderToString(Rax.createElement(RaxApp, pageConfig)),
-    global: JSON.stringify(pageConfig)
-  });
-
-});
-
+// note that we don't compile the vue route because the vue renderer is not
+// compatible with webpack; it uses require in an unusual way that webpack does
+// not understand.
 router.get('/vue', function *() {
 
   const VueApp = require('./assets/build/server.vue.bundle').default;

--- a/benchmarks/raxRenderToString.js
+++ b/benchmarks/raxRenderToString.js
@@ -3,7 +3,7 @@
 const Rax = require('rax');
 const raxRenderToString = require('rax-server-renderer').renderToString;
 
-const RxApp = require('../assets/build/server.rax.bundle').default;
+const RxApp = require('../assets/src/app.rax').default;
 
 const appProps = {
   listData: require('../mock/list'),

--- a/benchmarks/reactRenderToString.js
+++ b/benchmarks/reactRenderToString.js
@@ -3,7 +3,7 @@
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 
-const ReactApp = require('../assets/build/server.react.bundle').default;
+const ReactApp = require('../assets/src/app.react').default;
 
 const appProps = {
   listData: require('../mock/list'),

--- a/benchmarks/renderToString.js
+++ b/benchmarks/renderToString.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const path = require('path');
 /**
  * compare renderToString
  */
@@ -9,9 +9,9 @@ const cp = require('child_process');
 const limit = 10;
 
 // Independent process serial execution 10 times, each process parallel rendering 100 times
-runRenderTask(__dirname + '/raxRenderToString.js', limit)
-  .then(() => runRenderTask(__dirname + '/reactRenderToString.js', limit))
-  .then(() => runRenderTask(__dirname + '/vueRenderToString.js', limit))
+runRenderTask(path.join(__dirname, '..', 'assets', 'build', 'renderToString.rax.bundle.js'), limit)
+  .then(() => runRenderTask(path.join(__dirname, '..', 'assets', 'build', 'renderToString.react.bundle.js'), limit))
+  .then(() => runRenderTask(path.join(__dirname, 'vueRenderToString.js'), limit))
   .catch((err) => {
     console.log('Got Err:', err.stack);
   });

--- a/benchmarks/vueRenderToString.js
+++ b/benchmarks/vueRenderToString.js
@@ -3,7 +3,11 @@
 const Vue = require('vue');
 const vueRenderToString = require('vue-server-renderer').createRenderer().renderToString;
 
-const VueApp = require('../assets/build/server.vue.bundle').default;
+// note that this is different than the other benchmarks, which directly require
+// ../assets/src/app.xxx. This is because we can't webpack this file (vueRenderToString).
+// If we try we get errors because vue-server-renderer use require in unusual ways.
+// So instead we leave this file un-webpack-ed and bundle up just the vue app code.
+const VueApp = require('../assets/build/app.vue.bundle').default;
 
 const appProps = {
   listData: require('../mock/list'),
@@ -27,7 +31,7 @@ const total = 100;
 let count = 0;
 
 for (var i = 0; i < total; i++) {
-  
+
   vueRenderToString(vm, (err, html) => {
     count ++;
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "rax-ssr",
   "main": "app.js",
   "scripts": {
-    "start": "nodemon app.js",
+    "start": "NODE_ENV=production nodemon app.js",
     "webpack:client": "webpack --config webpack.client.config.js",
     "webpack:server": "webpack --config webpack.server.config.js",
     "webpack": "npm run webpack:client && npm run webpack:server",
-    "benchmark": "bash ./benchmarks/index.sh"
+    "benchmark": "NODE_ENV=production bash ./benchmarks/index.sh"
   },
   "keywords": [
     "ssr",
@@ -40,6 +40,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.8",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-plugin-transform-vue-jsx": "^3.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/routes/route.rax.js
+++ b/routes/route.rax.js
@@ -1,0 +1,18 @@
+import RaxApp from '../assets/src/app.rax'
+const Rax = require('rax');
+import { renderToString } from 'rax-server-renderer'
+
+export default function *() {
+
+  const pageConfig = {
+    listData: require('../mock/list'),
+    bannerData: require('../mock/banner')
+  };
+
+  yield this.render('page', {
+    type: 'rax',
+    content: renderToString(Rax.createElement(RaxApp, pageConfig)),
+    global: JSON.stringify(pageConfig)
+  });
+
+}

--- a/routes/route.react.js
+++ b/routes/route.react.js
@@ -1,0 +1,19 @@
+import ReactApp from '../assets/src/app.react'
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+
+export default function *() {
+
+  const pageConfig = {
+    listData: require('../mock/list'),
+    bannerData: require('../mock/banner')
+  };
+
+  yield this.render('page', {
+    type: 'react',
+    content: ReactDOMServer.renderToString(
+                React.createElement(ReactApp, pageConfig)
+              ),
+    global: JSON.stringify(pageConfig)
+  });
+}

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -5,9 +5,17 @@ var webpack = require('webpack');
 module.exports = {
   target: 'node',
   entry: {
-    'server.react': './assets/src/server.react.js',
-    'server.rax': './assets/src/server.rax.js',
-    'server.vue': './assets/src/server.vue.js'
+    'app.react': './assets/src/server.react.js',
+    'app.rax': './assets/src/server.rax.js',
+    'app.vue': './assets/src/server.vue.js',
+    'renderToString.react': './benchmarks/reactRenderToString.js',
+    'renderToString.rax': './benchmarks/raxRenderToString.js',
+    'route.react': './routes/route.react.js',
+    'route.rax': './routes/route.rax.js',
+    // we can't webpack vue because the renderer code for vue uses require in
+    // an unusual way.
+    // 'vueToString.react': './benchmarks/vueRenderToString.js',
+    // 'route.vue': './routes/vueRoute.js',
   },
   output: {
     filename: './assets/build/[name].bundle.js',
@@ -20,6 +28,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel',
         query: {
+          'plugins': ['transform-runtime'],
           'presets': ['es2015', 'react', 'stage-0']
         }
       },
@@ -35,5 +44,12 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': '"production"'
+      }
+    }),
+  ],
 };


### PR DESCRIPTION
While PR #3 was a good step towards following production best practices, it only went part way. Implementing prod mode in React rendering on the server has two parts:

1. Run node with `NODE_ENV=production` (which was accomplished in #3).
1. Compile out all calls to `process.env.NODE_ENV` altogether.

This is because `process.env` is not a simple JavaScript object, and it is surprisingly expensive to use it. Even when running in production mode, just the calls to check the `procces.env.NODE_ENV` can easily take 30% of rendering time in React.

In the current master code, this benchmark doesn't compile `react-dom/server` at all, so its perf is sub-optimal.

In this PR, I've implemented this change for both the `renderToString` benchmarks and the server benchmarks. To keep things apples to apples, I tried to compile out `process.env.NODE_ENV` for Rax and Vue, too. However, in Vue's case, I couldn't do it because Vue's renderer is not compatible with webpack. So the Vue code I left basically the same as it was, while I compile Rax and React to remove `process.env.NODE_ENV`. If anyone has expertise in Vue and can advise about perf optimization for it, I'd be grateful.

The qps benchmark seems to bounce around a lot from run to run (which I will file as a separate issue), but here's the data from a relatively representative run on my machine after these changes:

|  | renderToString | qps |
|---|---|---|
| Rax | 41.2ms | 1822 / sec |
| React | 44.8ms | 2005 / sec |
| Vue | 45.7ms | 1703 / sec |

Environment:  Retina MBP mid-2014, 2.8GHz i7, 16GB RAM, node 6.9.1

Thanks for all your work, and I'm excited to play around with Rax!
