### PR TITLE
Compiled out process.env.NODE_ENV for Rax and React benchmarks

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,8 @@ const koa = require('koa');
 const serve = require('koa-static');
 const router = require('koa-router')();
 
-const reactController = require('./controllers/react');
-const raxController = require('./controllers/rax');
+const reactController = require('./assets/build/controller.react.bundle');
+const raxController = require('./assets/build/controller.rax.bundle');
 const vueController = require('./controllers/vue');
 
 const app = require('xtpl/lib/koa')(require('koa')(), {

--- a/benchmarks/renderToString.js
+++ b/benchmarks/renderToString.js
@@ -6,51 +6,17 @@
 
 const Benchmark = require('benchmark');
 
-const Rax = require('rax');
-const raxRenderToString = require('rax-server-renderer').renderToString;
-const React = require('react');
-const ReactDOMServer = require('react-dom/server');
-const Vue = require('vue');
-const vueRenderToString = require('vue-server-renderer').createRenderer().renderToString;
 
-const ReactApp = require('../assets/build/server.react.bundle').default;
-const RaxApp = require('../assets/build/server.rax.bundle').default;
-const VueApp = require('../assets/build/server.vue.bundle').default;
-
-const data = {
-  listData: require('../mock/list'),
-  bannerData: require('../mock/banner')
-};
-
-const vueVm = new Vue({
-  render(h) {
-    return h(VueApp, {
-      attrs: {
-        listData: data.listData,
-        bannerData: data.bannerData
-      }
-    });
-  }
-});
+const reactRenderToString = require('../assets/build/renderToString.react.bundle');
+const raxRenderToString = require('../assets/build/renderToString.rax.bundle');
+const vueRenderToString = require('./renderToString.vue');
 
 const suite = new Benchmark.Suite;
 
 suite
-  .add('Rax#renderToString', function() {
-    raxRenderToString(Rax.createElement(RaxApp, data));
-  })
-  .add('React#renderToString', function() {
-    ReactDOMServer.renderToString(React.createElement(ReactApp, data));
-  })
-  .add('Vue#renderToString', function(deferred) {
-    vueRenderToString(vueVm, (err, html) => {
-      if(err) {
-        throw err;
-      } else {
-        deferred.resolve();
-      }
-    });
-  }, {defer: true})
+  .add('Rax#renderToString', raxRenderToString)
+  .add('React#renderToString', reactRenderToString)
+  .add('Vue#renderToString', vueRenderToString, {defer: true})
   // add listeners
   .on('cycle', function(event) {
     console.log(String(event.target));

--- a/benchmarks/renderToString.rax.js
+++ b/benchmarks/renderToString.rax.js
@@ -1,0 +1,12 @@
+const Rax = require('rax');
+const raxRenderToString = require('rax-server-renderer').renderToString;
+const RaxApp = require('../assets/src/app.rax').default;
+
+const data = {
+  listData: require('../mock/list'),
+  bannerData: require('../mock/banner')
+};
+
+module.exports = function() {
+  raxRenderToString(Rax.createElement(RaxApp, data));
+};

--- a/benchmarks/renderToString.react.js
+++ b/benchmarks/renderToString.react.js
@@ -1,0 +1,12 @@
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const ReactApp = require('../assets/src/app.react').default;
+
+const data = {
+  listData: require('../mock/list'),
+  bannerData: require('../mock/banner')
+};
+
+module.exports = function() {
+  ReactDOMServer.renderToString(React.createElement(ReactApp, data));
+};

--- a/benchmarks/renderToString.vue.js
+++ b/benchmarks/renderToString.vue.js
@@ -1,0 +1,29 @@
+const Vue = require('vue');
+const vueRenderToString = require('vue-server-renderer').createRenderer().renderToString;
+const VueApp = require('../assets/build/server.vue.bundle').default;
+
+const data = {
+  listData: require('../mock/list'),
+  bannerData: require('../mock/banner')
+};
+
+const vueVm = new Vue({
+  render(h) {
+    return h(VueApp, {
+      attrs: {
+        listData: data.listData,
+        bannerData: data.bannerData
+      }
+    });
+  }
+});
+
+module.exports = function(deferred) {
+  vueRenderToString(vueVm, (err, html) => {
+    if(err) {
+      throw err;
+    } else {
+      deferred.resolve();
+    }
+  });
+};

--- a/controllers/rax.js
+++ b/controllers/rax.js
@@ -6,7 +6,7 @@ module.exports = {
 
     home: function* () {
 
-        const RaxApp = require('../assets/build/server.rax.bundle').default;
+        const RaxApp = require('../assets/src/app.rax').default;
         const pageConfig = {
             listData: require('../mock/list'),
             bannerData: require('../mock/banner')

--- a/controllers/react.js
+++ b/controllers/react.js
@@ -6,7 +6,7 @@ module.exports = {
 
     home: function* () {
 
-        const ReactApp = require('../assets/build/server.react.bundle').default;
+        const ReactApp = require('../assets/src/app.react').default;
 
         const pageConfig = {
             listData: require('../mock/list'),

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.8",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-plugin-transform-vue-jsx": "^3.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -7,7 +7,15 @@ module.exports = {
   entry: {
     'server.react': './assets/src/server.react.js',
     'server.rax': './assets/src/server.rax.js',
-    'server.vue': './assets/src/server.vue.js'
+    'server.vue': './assets/src/server.vue.js',
+    'renderToString.react': './benchmarks/renderToString.react.js',
+    'renderToString.rax': './benchmarks/renderToString.rax.js',
+    // Vue is not compatible with webpack, so we don't compile it.
+    // 'server.vue': './assets/benchmarks/renderToString.vue.js',
+    'controller.react': './controllers/react.js',
+    'controller.rax': './controllers/rax.js',
+    // Vue is not compatible with webpack, so we don't compile it.
+    // 'controller.vue': './controllers/vue.js',
   },
   output: {
     filename: './assets/build/[name].bundle.js',
@@ -20,6 +28,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel',
         query: {
+          'plugins': ['transform-runtime'],
           'presets': ['es2015', 'react', 'stage-0']
         }
       },


### PR DESCRIPTION
This is a new version of #5, built on top of #7. It compiles out `process.env.NODE_ENV` in both the Rax and React benchmarks, in both the `renderToString` and server versions. It cannot compile out `process.env.NODE_ENV` in Vue because Vue's server renderer is not webpack-compatible.

For more background, read #5, #6, and #7.

On my machine, before this PR, I get:

```
-----------compare renderToString----------
Rax#renderToString x 93.54 ops/sec ±3.63% (65 runs sampled)
React#renderToString x 58.27 ops/sec ±1.49% (58 runs sampled)
Vue#renderToString x 205 ops/sec ±4.16% (72 runs sampled)
Fastest is Vue#renderToString
```

And after:

```
-----------compare renderToString----------
Rax#renderToString x 93.09 ops/sec ±4.20% (58 runs sampled)
React#renderToString x 140 ops/sec ±1.29% (74 runs sampled)
Vue#renderToString x 207 ops/sec ±4.22% (72 runs sampled)
Fastest is Vue#renderToString
```