### PR TITLE
add fast-react

### DIFF
--- a/assets/src/app/banner/index.fast_react.js
+++ b/assets/src/app/banner/index.fast_react.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import React from 'fast-react-server';
+import styles from './styles';
+
+export default class Banner extends React.Component {
+
+  state = {
+    data: this.props.data || []
+  };
+
+  onBannerClick = (item) => {
+    alert('click banner:' + item.title);
+  }
+
+  render() {
+    const {data} = this.state;
+
+    return (
+      <div style={styles.container}>
+        <h2>React Banner: </h2>
+        <div style={styles.list}>
+        {
+          data.map((item, idx) => {
+            return (
+              <div style={styles.item} onClick={this.onBannerClick.bind(this, item)}>
+                <img src={item.img} style={styles.itemImg} />
+              </div>
+            );
+          })
+        }
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/assets/src/app/index.fast_react.js
+++ b/assets/src/app/index.fast_react.js
@@ -1,0 +1,23 @@
+import React from 'fast-react-server';
+import List from './list/index.fast_react';
+import Banner from './banner/index.fast_react';
+
+export default class App extends React.Component {
+
+  componentDidMount() {
+    // console.log('react render in client');
+  }
+
+  render() {
+
+    const props = this.props || {};
+
+    return (
+      <div>
+        <Banner cacheKey={"banner"} data={props.bannerData} />
+        <List cacheKey={"list"} data={props.listData} />
+      </div>
+    );
+
+  }
+};

--- a/assets/src/app/list/index.fast_react.js
+++ b/assets/src/app/list/index.fast_react.js
@@ -1,0 +1,35 @@
+'use strict';
+
+import React, { Component } from 'fast-react-server';
+import styles from './styles';
+
+export default class List extends Component {
+
+  state = {
+    data: this.props.data || []
+  };
+
+  render() {
+    const { data } = this.state;
+    return (
+      <div style={styles.container}>
+        <h2>ReactList</h2>
+        <div style={styles.list}>
+        {
+          data.map((item, idx) => {
+            return (
+              <a key={idx} style={styles.item} href={item.url}>
+                <img src={item.img} style={styles.itemImg} />
+                <p style={styles.itemTitle}>{item.title}</p>
+                <p style={styles.itemPrice}>
+                  <span>price: {item.price}</span>
+                </p>
+              </a>
+            );
+          })
+        }
+        </div>
+      </div>
+    );
+  }
+}

--- a/assets/src/server.fast_react.js
+++ b/assets/src/server.fast_react.js
@@ -1,0 +1,1 @@
+module.exports = require('./app/index.fast_react');

--- a/benchmarks/renderToString.js
+++ b/benchmarks/renderToString.js
@@ -11,6 +11,8 @@ const Rax = require('rax');
 const raxRenderToString = require('rax-server-renderer').renderToString;
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
+const FastReact = require('fast-react-server');
+const FastReactRender = require('fast-react-render');
 const Vue = require('vue');
 const vueRenderToString = require('vue-server-renderer').createRenderer().renderToString;
 const Preact = require('preact');
@@ -20,6 +22,7 @@ const infernoCreateElement = require('inferno-create-element');
 const {render} = require("rapscallion");
 
 const ReactApp = require('../assets/build/server.react.bundle').default;
+const FastReactApp = require('../assets/build/server.fast_react.bundle').default;
 const RaxApp = require('../assets/build/server.rax.bundle').default;
 const VueApp = require('../assets/build/server.vue.bundle').default;
 const PreactApp = require('../assets/build/server.preact.bundle').default;
@@ -50,6 +53,9 @@ const suite = new Benchmark.Suite;
 suite
   .add('React#renderToString', function() {
     ReactDOMServer.renderToString(React.createElement(ReactApp, data));
+  })
+  .add('FastReact#elementToString', function() {
+    FastReactRender.elementToString(FastReact.createElement(FastReactApp, data));
   })
   .add('Rax#renderToString', function() {
     raxRenderToString(Rax.createElement(RaxApp, data));

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "name": "imsobear"
   },
   "dependencies": {
+    "fast-react-render": "^1.2.2",
+    "fast-react-server": "^1.4.1",
     "inferno": "latest",
     "inferno-component": "latest",
     "inferno-create-element": "latest",

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -7,6 +7,7 @@ module.exports = {
   entry: {
     'server.marko': './assets/src/app/index.marko',
     'server.react': './assets/src/server.react.js',
+    'server.fast_react': './assets/src/server.fast_react.js',
     'server.rax': './assets/src/server.rax.js',
     'server.preact': './assets/src/server.preact.js',
     'server.vue': './assets/src/server.vue.js',
@@ -19,7 +20,7 @@ module.exports = {
   module: {
     loaders:[
       {
-        test: /(preact|rax|react|.)\.js[x]?$/,
+        test: /(preact|rax|react|fast_react|.)\.js[x]?$/,
         exclude: /node_modules/,
         loader: 'babel',
         query: {


### PR DESCRIPTION
[fast-react](https://github.com/alt-j/fast-react-servefast-react) is a fast react server renderToString implementation

```
  | React#renderToString      | x 154 ops/sec   | ±1.63% (79 runs sampled) |
  | FastReact#elementToString | x 1,001 ops/sec | ±0.74% (92 runs sampled) |
  | Rax#renderToString        | x 334 ops/sec   | ±3.77% (77 runs sampled) |
  | Preact#renderToString     | x 1,032 ops/sec | ±0.29% (92 runs sampled) |
  | Rapscallion#render        | x 2,537 ops/sec | ±0.32% (88 runs sampled) |
  | Marko#renderToString      | x 8,115 ops/sec | ±0.35% (89 runs sampled) |
  | Xtpl#renderFile           | x 8,327 ops/sec | ±3.76% (70 runs sampled) |
```