### PR TITLE
Fix inferno build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.8",
-    "babel-plugin-inferno": "^1.7.0",
+    "babel-plugin-inferno": "^3.2.0",
+    "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -27,15 +27,13 @@ module.exports = {
         }
       },
       {
-          test: /\.inferno\.js?$/,
-          exclude: /node_modules/,
-          loader: 'babel',
-          query: {
-              'presets': ['es2015', 'stage-0'],
-              'plugins': [
-                  'inferno'
-              ]
-          }
+        test: /\.inferno\.js?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'stage-0'],
+          plugins: ['babel-plugin-syntax-jsx', 'inferno']
+        }
       },
       {
         test: /\.vue\.js?$/,

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -27,15 +27,13 @@ module.exports = {
         }
       },
       {
-          test: /\.inferno\.js?$/,
-          exclude: /node_modules/,
-          loader: 'babel',
-          query: {
-              'presets': ['es2015', 'stage-0'],
-              'plugins': [
-                  'inferno'
-              ]
-          }
+        test: /\.inferno\.js?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'stage-0'],
+          plugins: ['babel-plugin-syntax-jsx', 'inferno']
+        }
       },
       {
         test: /\.vue\.js?$/,


### PR DESCRIPTION
Inferno benchmarks were broken, since it wasn't actually rendering the full tree. See #16.

After some tests and seeing nothing wrong I went to the docs for setting up the project and checked what was missing in the benchmark build config.

Apparently `babel-plugin-syntax-jsx`is needed now along the inferno plugin. After adding it, and running the benchmarks, the rendering is working fine again.

Fixes #16 