### PR TITLE
Fixed Inferno + activated Vue.js benchmark

### DIFF
--- a/benchmarks/renderToString.js
+++ b/benchmarks/renderToString.js
@@ -34,17 +34,6 @@ const data = {
   bannerData: require('../mock/banner')
 };
 
-const vueVm = new Vue({
-  render(h) {
-    return h(VueApp, {
-      attrs: {
-        listData: data.listData,
-        bannerData: data.bannerData
-      }
-    });
-  }
-});
-
 const suite = new Benchmark.Suite;
 
 suite
@@ -65,6 +54,24 @@ suite
     .then(htmlString => {
       deferred.resolve();
     });;
+  }, {defer: true})
+  .add('Vue#renderToString', function(deferred) {
+    const vueVm = new Vue({
+      render(h) {
+        return h(VueApp, {
+          attrs: {
+            listData: data.listData,
+            bannerData: data.bannerData
+          }
+        });
+      }
+    });
+    vueRenderToString(vueVm, (err, html) => {
+      if(err) {
+        return deferred.reject(err);
+      }
+      deferred.resolve();
+    });
   }, {defer: true})
   .add('Marko#renderToString', function() {
     MarkoApp.renderToString(data);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.8",
-    "babel-plugin-inferno": "^1.7.0",
+    "babel-plugin-inferno": "^3.2.0",
+    "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -27,15 +27,13 @@ module.exports = {
         }
       },
       {
-          test: /\.inferno\.js?$/,
-          exclude: /node_modules/,
-          loader: 'babel',
-          query: {
-              'presets': ['es2015', 'stage-0'],
-              'plugins': [
-                  'inferno'
-              ]
-          }
+        test: /\.inferno\.js?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'stage-0'],
+          plugins: ['babel-plugin-syntax-jsx', 'inferno']
+        }
       },
       {
         test: /\.vue\.js?$/,

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -27,15 +27,13 @@ module.exports = {
         }
       },
       {
-          test: /\.inferno\.js?$/,
-          exclude: /node_modules/,
-          loader: 'babel',
-          query: {
-              'presets': ['es2015', 'stage-0'],
-              'plugins': [
-                  'inferno'
-              ]
-          }
+        test: /\.inferno\.js?$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'stage-0'],
+          plugins: ['babel-plugin-syntax-jsx', 'inferno']
+        }
       },
       {
         test: /\.vue\.js?$/,


### PR DESCRIPTION
Inferno fix from PR #18 
Added Vue.js benchmark in the suite.
Here are my results:

React#renderToString x 218 ops/sec ±1.37% (79 runs sampled)
Rax#renderToString x 336 ops/sec ±3.84% (71 runs sampled)
Inferno#renderToString x 1,950 ops/sec ±1.30% (83 runs sampled)
Preact#renderToString x 1,188 ops/sec ±1.78% (85 runs sampled)
Rapscallion#render x 1,635 ops/sec ±2.19% (79 runs sampled)
Vue#renderToString x 675 ops/sec ±3.92% (71 runs sampled)
Marko#renderToString x 7,473 ops/sec ±1.49% (81 runs sampled)
Xtpl#renderFile x 9,147 ops/sec ±4.64% (64 runs sampled)
Fastest is Xtpl#renderFile