### PR TITLE
fix: delay in deferred callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ NODE_ENV=production node benchmarks/renderToString.js
 React(16.12.0)#renderToString x 1,664 ops/sec ±1.40% (84 runs sampled)
 Rax(1.0.13)#renderToString x 13,411 ops/sec ±1.05% (85 runs sampled)
 Preact(10.0.5)#renderToString x 1,237 ops/sec ±2.18% (84 runs sampled)
-Xtpl(3.4.2)#renderFile x 11,335 ops/sec ±8.17% (69 runs sampled)
 
 The benchmark was run on:
    PLATFORM: darwin 17.5.0

--- a/controllers/xtpl.js
+++ b/controllers/xtpl.js
@@ -1,23 +1,21 @@
-
-const Rax = require('rax');
-const xtpl = require('xtpl');
 const path = require('path');
+const fs = require('fs');
+const xtemplate = require('xtemplate');
 
 module.exports = {
 
     home: function* () {
-
-        const xtplAppPath = path.join(__dirname, '../assets/src/app/index.xtpl');
         const pageConfig = {
             listData: require('../mock/list'),
             bannerData: require('../mock/banner')
         };
 
-        const content = yield new Promise((resolve, reject) => {
-          xtpl.renderFile(xtplAppPath, pageConfig, function(error, content){
-            resolve(content)
-          });
-        });
+        const xtplPath = path.join(__dirname, '../assets/src/app/index.xtpl');
+        const xtplString = fs.readFileSync(xtplPath, 'utf8');
+        const xtpl = xtemplate.compile(xtplString);
+        const xtplApp = new xtemplate(xtpl);
+
+        const content = xtplApp.render(pageConfig);
 
         yield this.render('page', {
           type: 'xtpl',


### PR DESCRIPTION
Fix benchmarks for vue and xtpl, because call deferred.resolve in the callback of a function, it will bring more delay time.（it may be a bug of benchmark.js)

different result when call `deferred.resolve`  in promise.then and callback

```bash
promise x 8,440,317 ops/sec ±1.09% (81 runs sampled)
callback x 205,368 ops/sec ±16.45% (43 runs sampled)
```