### PR TITLE
Add Hyperapp Render

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const koa = require('koa');
 const serve = require('koa-static');
 const router = require('koa-router')();
 
+const hyperappController = require('./controllers/hyperapp');
 const reactController = require('./controllers/react');
 const raxController = require('./controllers/rax');
 const vueController = require('./controllers/vue');
@@ -19,6 +20,7 @@ const app = require('xtpl/lib/koa')(require('koa')(), {
   views:'./views'
 });
 
+router.get('/hyperapp', hyperappController.home);
 router.get('/react', reactController.home);
 router.get('/rax', raxController.home);
 router.get('/vue', vueController.home);

--- a/assets/src/app/banner/index.hyperapp.js
+++ b/assets/src/app/banner/index.hyperapp.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+import { h } from "hyperapp";
+
+export const init = [];
+
+const alertFx = (dispatch, { message }) => alert(message);
+const alertEffect = message => [alertFx, { message }];
+
+const ClickAction = (state, item) => [state, alertEffect("click banner:" + item.title)];
+
+export const view = state => (
+  <div class="container">
+    <h2>Hyperapp Banner: </h2>
+    <div class="list">
+      {state.map((item, idx) => (
+        <div key={idx} class="item" onclick={[ClickAction, item]}>
+          <img src={item.img} class="itemImg" />
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/assets/src/app/index.hyperapp.js
+++ b/assets/src/app/index.hyperapp.js
@@ -1,0 +1,17 @@
+
+/** @jsx h */
+import { h } from 'hyperapp';
+import * as Banner from './banner/index.hyperapp';
+import * as List from './list/index.hyperapp';
+
+export const init = {
+  bannerData: Banner.init,
+  listData: List.init,
+};
+
+export const view = (state) => (
+  <div>
+    {Banner.view(state.bannerData)}
+    {List.view(state.listData)}
+  </div>
+);

--- a/assets/src/app/list/index.hyperapp.js
+++ b/assets/src/app/list/index.hyperapp.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+import { h } from "hyperapp";
+
+export const init = [];
+
+export const view = state => (
+  <div class="container">
+    <h2>HyperappList</h2>
+    <div class="list">
+      {state.map((item, idx) => (
+        <a key={idx} class="item" href={item.url}>
+          <img src={item.img} class="itemImg" />
+          <p class="itemTitle">{item.title}</p>
+          <p class="itemPrice">
+            <span>price: {item.price}</span>
+          </p>
+        </a>
+      ))}
+    </div>
+  </div>
+);

--- a/assets/src/client.hyperapp.js
+++ b/assets/src/client.hyperapp.js
@@ -1,0 +1,5 @@
+import { app } from 'hyperapp';
+
+import { init, view } from './app/index.hyperapp';
+
+app({ init, view, node: document.getElementById('container') });

--- a/assets/src/server.hyperapp.js
+++ b/assets/src/server.hyperapp.js
@@ -1,0 +1,1 @@
+module.exports = require('./app/index.hyperapp');

--- a/benchmarks/renderToString.js
+++ b/benchmarks/renderToString.js
@@ -18,7 +18,9 @@ const Preact = require('preact');
 const preactRenderToString = require('preact-render-to-string');
 const InfernoServer = require('inferno-server');
 const infernoCreateElement = require('inferno-create-element');
+const Hyperapp = require('hyperapp-render');
 
+const hyperappPkg = require('hyperapp/package.json');
 const reactPkg = require('react/package.json');
 const raxPkg = require('rax/package.json');
 const infernoPkg = require('inferno/package.json');
@@ -27,6 +29,7 @@ const vuePkg = require('vue/package.json');
 const markoPkg = require('marko/package.json');
 const xtemplatePkg = require('xtemplate/package.json');
 
+const HyperApp = require('../assets/build/server.hyperapp.bundle');
 const ReactApp = require('../assets/build/server.react.bundle').default;
 const RaxApp = require('../assets/build/server.rax.bundle').default;
 const VueApp = require('../assets/build/server.vue.bundle').default;
@@ -46,6 +49,9 @@ const data = {
 const suite = new Benchmark.Suite;
 
 suite
+  .add(`Hyperapp(${hyperappPkg.version})#renderToString`, function() {
+    Hyperapp.renderToString(HyperApp.view(data));
+  })
   .add(`React(${reactPkg.version})#renderToString`, function() {
     ReactDOMServer.renderToString(React.createElement(ReactApp, data));
   })

--- a/controllers/hyperapp.js
+++ b/controllers/hyperapp.js
@@ -1,0 +1,16 @@
+const { renderToString } = require("hyperapp-render");
+
+module.exports = {
+  home: function*() {
+    const Hyperapp = require("../assets/build/server.hyperapp.bundle").default;
+    const pageConfig = {
+      listData: require("../mock/list"),
+      bannerData: require("../mock/banner")
+    };
+    yield this.render("page", {
+      type: "hyperapp",
+      content: renderToString(Hyperapp.view, Hyperapp.init),
+      global: JSON.stringify(pageConfig)
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "driver-dom": "^2.0.0",
+    "hyperapp": "^2.0.3",
+    "hyperapp-render": "^3.1.0",
     "inferno": "^7.2.1",
     "inferno-create-element": "^7.3.0",
     "inferno-hydrate": "^7.3.1",

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -5,6 +5,7 @@ var webpack = require('webpack');
 module.exports = {
   mode: 'production',
   entry: {
+    'client.hyperapp': './assets/src/client.hyperapp.js',
     'client.marko': './assets/src/client.marko.js',
     'client.react': './assets/src/client.react.js',
     'client.rax': './assets/src/client.rax.js',
@@ -18,6 +19,24 @@ module.exports = {
   },
   module: {
     rules:[
+      {
+        test: /\.hyperapp\.js?$/,
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            [require.resolve('@babel/preset-env'), {
+              targets: {
+                browsers: ['last 2 versions', 'IE >= 9']
+              },
+              modules: false,
+              loose: true
+            }],
+          ],
+          plugins: [
+            [require.resolve('@babel/plugin-transform-react-jsx'), {pragma: 'h'}],
+          ]
+        }
+      },
       // react & rax
       {
         test: /(rax|react|.)\.jsx?$/,
@@ -104,6 +123,7 @@ module.exports = {
     ]
   },
   externals: {
+    'hyperapp': 'window.hyperapp',
     'react': 'window.React',
     'react-dom': 'window.ReactDOM',
     'rax': 'window.Rax',

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -6,6 +6,7 @@ module.exports = {
   target: 'node',
   mode: 'production', // 'development',
   entry: {
+    'server.hyperapp': './assets/src/server.hyperapp.js',
     'server.marko': './assets/src/app/index.marko',
     'server.react': './assets/src/server.react.js',
     'server.rax': './assets/src/server.rax.js',
@@ -20,6 +21,22 @@ module.exports = {
   },
   module: {
     rules:[
+      {
+        test: /\.hyperapp\.js?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            [require.resolve('@babel/preset-env'), {
+              modules: false,
+              loose: true
+            }],
+          ],
+          plugins: [
+            [require.resolve('@babel/plugin-transform-react-jsx'), {pragma: 'h'}],
+          ]
+        }
+      },
       {
         test: /\.react.*\.js/,
         exclude: /node_modules/,


### PR DESCRIPTION
Continues #24 (rebased on fresh master)

```shell
-----------compare renderToString----------
Hyperapp(2.0.3)#renderToString x 4,735 ops/sec ±1.11% (88 runs sampled)
React(16.12.0)#renderToString x 1,906 ops/sec ±1.26% (87 runs sampled)
Rax(1.1.1)#renderToString x 10,165 ops/sec ±1.34% (90 runs sampled)
Inferno(7.3.3)#renderToString x 5,180 ops/sec ±1.34% (87 runs sampled)
Preact(10.2.1)#renderToString x 1,268 ops/sec ±2.12% (87 runs sampled)
Vue(2.6.11)#renderToString x 1,098 ops/sec ±1.94% (80 runs sampled)
Marko(4.18.33)#renderToString x 12,893 ops/sec ±0.61% (87 runs sampled)
xtemplate(4.7.2)#render x 29,189 ops/sec ±0.61% (91 runs sampled)

The benchmark was run on:
   PLATFORM: darwin 19.2.0
   CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
   SYSTEM MEMORY: 16GB
   NODE VERSION: v13.6.0
```
See:
- [hyperapp](https://github.com/hyperapp/hyperapp)
- [hyperapp-render](https://github.com/frenzzy/hyperapp-render)