### PR TITLE
marko: update for-tag

### DIFF
--- a/assets/src/app/banner/index.marko
+++ b/assets/src/app/banner/index.marko
@@ -12,8 +12,10 @@ class {
 <div class="container">
   <h2>${state.title}</h2>
   <div class="list">
-    <div for(idx, item in data.items) class="item" on-click('onBannerClick', item.title)>
-      <img src=item.img class="itemImg" />
-    </div>
+    <for|idx, item| in=data.items>
+      <div class="item" on-click('onBannerClick', item.title)>
+        <img src=item.img class="itemImg" />
+      </div>
+    </for>
   </div>
 </div>

--- a/assets/src/app/list/index.marko
+++ b/assets/src/app/list/index.marko
@@ -1,12 +1,14 @@
 <div class="container">
   <h2>MarkoList</h2>
   <div class="list">
-    <a for(idx, item in data.items) class="item" href=item.url>
-      <img src=item.img class="itemImg" />
-      <p class="itemTitle">${item.title}</p>
-      <p class="itemPrice">
-        <span>price: ${item.price}</span>
-      </p>
-    </a>
+    <for|idx, item| in=data.items>
+      <a class="item" href=item.url>
+        <img src=item.img class="itemImg" />
+        <p class="itemTitle">${item.title}</p>
+        <p class="itemPrice">
+          <span>price: ${item.price}</span>
+        </p>
+      </a>
+    </for>
   </div>
 </div>


### PR DESCRIPTION
to fix these warnings:
```
npm run webpack

MIGRATION
The "for" attribute is deprecated. Please use the <for> tag instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-control-flow-attributes
  at assets/src/app/banner/index.marko:15:4
```

FYI:

| package                       |    ops/sec    |        runs sampled |
| ----------------------------- | :-----------: | ------------------: |
| React(17.0.1)#renderToString | 1,780 ±1.16 | % (86 runs sampled) |
| Rax(1.1.4)#renderToString | 9,069 ±0.91 | % (86 runs sampled) |
| Inferno(7.4.6)#renderToString | 5,256 ±2.00 | % (85 runs sampled) |
| Preact(10.5.7)#renderToString | 1,309 ±0.71 | % (86 runs sampled) |
| Vue(2.6.12)#renderToString | 1,123 ±1.69 | % (79 runs sampled) |
| Marko(4.23.9)#renderToString | 14,579 ±0.80 | % (86 runs sampled) |
| xtemplate(4.7.2)#render | 27,178 ±4.30 | % (84 runs sampled) |